### PR TITLE
Add bot detail and auth pages

### DIFF
--- a/src/app/bots/[id]/page.js
+++ b/src/app/bots/[id]/page.js
@@ -1,0 +1,64 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { getBotById } from '@/data/bots'
+
+export default function BotDetailPage({ params }) {
+  const bot = getBotById(params.id)
+
+  if (!bot) {
+    return (
+      <main className="bg-[#1a1a1a] min-h-screen flex items-center justify-center">
+        <div className="text-white text-2xl">Bot bulunamadı</div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="bg-[#1a1a1a] min-h-screen py-20">
+      <div className="max-w-[1200px] mx-auto px-4 grid md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-2 gap-4">
+          {bot.images.map((img, idx) => (
+            <div key={idx} className="relative w-full h-40 sm:h-56 bg-[#232323] rounded-lg overflow-hidden">
+              <Image src={img} alt={`${bot.name} ${idx + 1}`} fill className="object-cover" />
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col">
+          <h1 className="text-3xl font-bold text-white mb-4">{bot.name}</h1>
+          <p className="text-gray-300 mb-4">{bot.description}</p>
+          <div className="text-3xl font-bold text-[#678FFF] mb-6">{bot.price}</div>
+          <h3 className="text-white font-semibold mb-2">Özellikler</h3>
+          <ul className="space-y-2 text-gray-300 mb-8">
+            {bot.features.map((feature, index) => (
+              <li key={index} className="flex items-start">
+                <svg
+                  className="w-5 h-5 text-[#678FFF] mt-1 mr-3 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                {feature}
+              </li>
+            ))}
+          </ul>
+          <div className="flex gap-4">
+            <Link
+              href={`/bots/${bot.id}/order`}
+              className="bg-[#678FFF] text-white px-8 py-3 rounded-lg font-semibold hover:bg-[#4A55A2] transition-colors duration-300 text-center"
+            >
+              Sipariş Ver
+            </Link>
+            <Link
+              href="/bots"
+              className="bg-transparent border-2 border-[#678FFF] text-[#678FFF] px-8 py-3 rounded-lg font-semibold hover:bg-[#678FFF] hover:text-white transition-colors duration-300 text-center"
+            >
+              Geri Dön
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/bots/page.js
+++ b/src/app/bots/page.js
@@ -3,6 +3,7 @@
 import BotCard from '@/components/BotCard'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
+import { bots } from '@/data/bots'
 
 export default function BotsPage() {
   const [botCount, setBotCount] = useState(12)
@@ -16,41 +17,6 @@ export default function BotsPage() {
     return () => clearInterval(interval)
   }, [])
 
-  const bots = [
-    {
-      id: 1,
-      name: "Kayıt Botu",
-      description: "Discord'a gelen üyelerinizi kayıt etmenizi sağlar!",
-      image: "/bots/bot.png",
-      features: [
-        "Kullanıcı kayıt işlemlerini otomatikleştirir.",
-        "Kullanıcı rollerini otomatik olarak atar.",
-        "Kayıt sırasında kullanıcı bilgilerini toplar.",
-      ]
-    },
-    {
-      id: 2,
-      name: "Moderasyon Botu",
-      description: "Sunucunuzu güvenle yönetmenizi sağlayan gelişmiş moderasyon botu!",
-      image: "/bots/moderation-bot.png",
-      features: [
-        "Otomatik spam koruması",
-        "Küfür ve hakaret filtreleme",
-        "Toplu mesaj silme",
-      ]
-    },
-    {
-      id: 3,
-      name: "Eğlence Botu",
-      description: "Sunucunuza eğlence katacak birbirinden farklı komutlar!",
-      image: "/bots/fun-bot.png",
-      features: [
-        "Müzik çalma özelliği",
-        "Mini oyunlar",
-        "Meme komutları",
-      ]
-    }
-  ]
 
   return (
     <main className="bg-[#1a1a1a]">

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -1,0 +1,31 @@
+'use client'
+
+export default function LoginPage() {
+  return (
+    <main className="bg-[#1a1a1a] min-h-screen flex items-center justify-center py-20">
+      <form className="bg-[#232323] p-8 rounded-xl w-full max-w-md space-y-6">
+        <h1 className="text-3xl font-bold text-white text-center">Giriş Yap</h1>
+        <div>
+          <label className="block text-sm text-gray-300 mb-2">E-posta</label>
+          <input
+            type="email"
+            className="w-full px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white focus:border-[#678FFF] focus:outline-none"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-300 mb-2">Şifre</label>
+          <input
+            type="password"
+            className="w-full px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white focus:border-[#678FFF] focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full bg-[#678FFF] hover:bg-[#4A55A2] text-white py-2 rounded-lg font-semibold transition-colors"
+        >
+          Giriş Yap
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/src/app/register/page.js
+++ b/src/app/register/page.js
@@ -1,0 +1,38 @@
+'use client'
+
+export default function RegisterPage() {
+  return (
+    <main className="bg-[#1a1a1a] min-h-screen flex items-center justify-center py-20">
+      <form className="bg-[#232323] p-8 rounded-xl w-full max-w-md space-y-6">
+        <h1 className="text-3xl font-bold text-white text-center">Kayıt Ol</h1>
+        <div>
+          <label className="block text-sm text-gray-300 mb-2">E-posta</label>
+          <input
+            type="email"
+            className="w-full px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white focus:border-[#678FFF] focus:outline-none"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-300 mb-2">Kullanıcı Adı</label>
+          <input
+            type="text"
+            className="w-full px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white focus:border-[#678FFF] focus:outline-none"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-300 mb-2">Şifre</label>
+          <input
+            type="password"
+            className="w-full px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white focus:border-[#678FFF] focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full bg-[#678FFF] hover:bg-[#4A55A2] text-white py-2 rounded-lg font-semibold transition-colors"
+        >
+          Kayıt Ol
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/src/data/bots.js
+++ b/src/data/bots.js
@@ -1,0 +1,57 @@
+export const bots = [
+  {
+    id: 1,
+    name: "Kayıt Botu",
+    description: "Discord'a gelen üyelerinizi kayıt etmenizi sağlar!",
+    price: "₺149.99",
+    image: "/bots/bot.png",
+    images: [
+      "/bots/bot.png",
+      "/bots/bot.png",
+      "/bots/bot.png"
+    ],
+    features: [
+      "Kullanıcı kayıt işlemlerini otomatikleştirir.",
+      "Kullanıcı rollerini otomatik olarak atar.",
+      "Kayıt sırasında kullanıcı bilgilerini toplar."
+    ]
+  },
+  {
+    id: 2,
+    name: "Moderasyon Botu",
+    description: "Sunucunuzu güvenle yönetmenizi sağlayan gelişmiş moderasyon botu!",
+    price: "₺199.99",
+    image: "/bots/bot.png",
+    images: [
+      "/bots/bot.png",
+      "/bots/bot.png",
+      "/bots/bot.png"
+    ],
+    features: [
+      "Otomatik spam koruması",
+      "Küfür ve hakaret filtreleme",
+      "Toplu mesaj silme"
+    ]
+  },
+  {
+    id: 3,
+    name: "Eğlence Botu",
+    description: "Sunucunuza eğlence katacak birbirinden farklı komutlar!",
+    price: "₺99.99",
+    image: "/bots/bot.png",
+    images: [
+      "/bots/bot.png",
+      "/bots/bot.png",
+      "/bots/bot.png"
+    ],
+    features: [
+      "Müzik çalma özelliği",
+      "Mini oyunlar",
+      "Meme komutları"
+    ]
+  }
+]
+
+export function getBotById(id) {
+  return bots.find(bot => bot.id === Number(id))
+}


### PR DESCRIPTION
## Summary
- Add shared bot data and per-bot detail pages showing gallery and price
- Wire bot list to shared data
- Create themed login and register forms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities in unrelated files)*
- `npx eslint src/app/bots/page.js src/app/bots/[id]/page.js src/app/login/page.js src/app/register/page.js src/data/bots.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad53c0a7b883259953cc3c942fc3f2